### PR TITLE
:speech_balloon: added: dynamic public ETH addr in pdf templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The backends communicate with the blockchain, broadcast the various transactions
 ## How to check node disponibility ?
 
 1.   Access API interface at  [http://127.0.0.1:8001/ctihorodateur/api/sonde](http://127.0.0.1:8001/api/sonde)
+
 ## Horodator API Environment variables
 
 Mandatory :
@@ -48,6 +49,21 @@ Mandatory :
 Optional :
 
 -   HTTP(S)_PROXY are environment variables used to specified a forward proxy for connection to pass through.
+
+## HTTPS support
+
+HTTPS support is provided via the docker images `jwilder/nginx-proxy`, `jrcs/nginx-proxy-lets-encrypt-companion` and
+[Let's Encrypt](https://letsencrypt.org/). The `nginx-proxy` image faces Internet and dispatches requests to the
+concerned service. Services that are reached from the Internet must have the following environment variables :  
+   
+  - `VIRTUAL_HOST` : The domain name associated to the service.  
+  - `LETSENCRYPT_HOST` : Same value as above, used by Let's Encrypt `certbot` to provide certificates.  
+  - `LETSENCRYPT_EMAIL` : Contact email for LetsEncrypt, used to notice certificate expiration. Note that certificates are automatically renewed while the companion is up.  
+
+Administrators must add an A record to their DNS configuration that points to the IP of the machine that hosts
+`nginx/proxy`. HTTPS should then be available in less than 5 minutes (time for Let'sEncrypt bot to provide certificates). 
+   
+
 
 ## Webapp Environment variables
 

--- a/horodateur_api/template/latex/template.de.tex
+++ b/horodateur_api/template/latex/template.de.tex
@@ -91,7 +91,7 @@ Alle Informationen zu dieser Erprobungsphase finden Sie unter folgendem Link: \h
 \href{https://etherscan.io/tx/0x{{ .SourceID }} }{ {{.SourceID }} }
 {{ end }}
 \item[Registre du Commerce Ethereum Anschrift] :\linebreak
-0x37478cade8ba5afac3440f0c6f0817909cc19576
+{{ .Address }}
 \item[Merkle Wurzel] :\linebreak
 {{ .MerkleRoot }}
 \item[Hashfunktion] : \linebreak

--- a/horodateur_api/template/latex/template.en.tex
+++ b/horodateur_api/template/latex/template.en.tex
@@ -91,7 +91,7 @@ You will find information about this experiment by following this link: \href{ht
 \href{https://etherscan.io/tx/0x{{ .SourceID }} }{ {{.SourceID }} }
 {{ end }}
 \item[Registre du commerce's Ethereum address] :\linebreak
-0x37478cade8ba5afac3440f0c6f0817909cc19576
+{{ .Address }}
 \item[Merkle root] :\linebreak
 {{ .MerkleRoot }}
 \item[Hash function] : \linebreak

--- a/horodateur_api/template/latex/template.fr.tex
+++ b/horodateur_api/template/latex/template.fr.tex
@@ -91,7 +91,7 @@ Vous retrouverez toutes les informations sur cette expérimentation sur ce lien 
 \href{https://etherscan.io/tx/0x{{ .SourceID }} }{ {{.SourceID }} }
 {{ end }}
 \item[Adresse Ethereum du Registre du commerce] :\linebreak
-0x37478cade8ba5afac3440f0c6f0817909cc19576
+{{ .Address }}
 \item[Racine de Merkle] :\linebreak
 {{ .MerkleRoot }}
 \item[Fonction de hachage] : \linebreak

--- a/horodateur_api/template/latex/template.it.tex
+++ b/horodateur_api/template/latex/template.it.tex
@@ -92,7 +92,7 @@ Per maggiori informazioni su questa fase di sperimentazione, si veda: \href{http
 {{ end }}
 \item[Indirizzo Ethereum del Registre du commerce
 ] :\linebreak
-0x37478cade8ba5afac3440f0c6f0817909cc19576
+{{ .Address }}
 \item[Radice di Merkle] :\linebreak
 {{ .MerkleRoot }}
 \item[Funzione di hash] : \linebreak


### PR DESCRIPTION
This commit removed the hardcoded ETH addr written in PDF receipt templates and replaced it with a dynamic public ETH addr made from env:$PRIVATE_KEY