### PR TITLE
Receipt deletion

### DIFF
--- a/horodateur_api/internal/handlers.go
+++ b/horodateur_api/internal/handlers.go
@@ -66,7 +66,27 @@ func GetreceiptHandler(ctx context.Context, params op.GetreceiptParams) middlewa
 
 func DelreceiptsHandler(ctx context.Context, params op.DelreceiptsParams) middleware.Responder {
 	for _, hash := range params.Hashes {
-		err := DelReceiptByHash(ctx, hash)
+		if(len(hash) == 0) {
+			err_str := fmt.Sprintf("Please make sure that hash \"%s\" is valid", hash)
+			log.Printf(err_str)
+			return op.NewDelreceiptsDefault(400).WithPayload(&models.Error{Message: &err_str})
+		}
+
+		_, ok, err := GetReceiptByHash(ctx, hash)
+		if err != nil {
+			err_str := fmt.Sprintf("Failed to call %s: %v", "GetReceiptByHash", err)
+			log.Printf(err_str)
+			return op.NewGetreceiptDefault(500).WithPayload(&models.Error{Message: &err_str})
+		}
+		if !ok {
+			err_str := fmt.Sprintf("No receipt found for %s", hash)
+			log.Printf(err_str)
+			return op.NewGetreceiptDefault(500).WithPayload(&models.Error{Message: &err_str})
+		}
+	}
+
+	for _, hash := range params.Hashes {
+		err = DelReceiptByHash(ctx, hash)
 		if err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
By passing `[""]` as a post parameter it was possible to delete all receipt.

To prevent that :

- Check of the hash length
-  Made sure receipt exists before deletion